### PR TITLE
Added apiUrl as an option to datadog client

### DIFF
--- a/src/datadog.js
+++ b/src/datadog.js
@@ -6,7 +6,7 @@ const stream = require('stream')
 class Client {
   constructor (options = {}) {
     this._apiKey = options.apiKey
-    this._apiUrl = options.apiUrl || "https://http-intake.logs.datadoghq.com/v1/"
+    this._apiUrl = options.apiUrl || 'https://http-intake.logs.datadoghq.com/v1/'
   }
 
   async insert (items = []) {

--- a/src/datadog.js
+++ b/src/datadog.js
@@ -6,13 +6,14 @@ const stream = require('stream')
 class Client {
   constructor (options = {}) {
     this._apiKey = options.apiKey
+    this._apiUrl = options.apiUrl || "https://http-intake.logs.datadoghq.com/v1/"
   }
 
   async insert (items = []) {
     const data = Array.isArray(items) ? items : [items]
     if (data.length <= 0) { return }
     try {
-      const url = `https://http-intake.logs.datadoghq.com/v1/input/${this._apiKey}`
+      const url = `${this._apiUrl}input/${this._apiKey}`
       const result = await axios.post(url, data)
       return result
     } catch (err) {


### PR DESCRIPTION
There are two zones in Datadog: US & Europe.

If you register in Europe zone, you can't use datadog.com, you have to use eu-version of their service.

This PR adds support to specify particular API endpoint to Datadog constructor, thus allowing to connect to Eu-based accounts, at least through API.