### PR TITLE
Forward logs to stdout

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -15,7 +15,7 @@ function main () {
         const apiKey = key || process.env.DD_API_KEY
         const writeStream = await pinoDataDog.createWriteStream({ apiKey })
         process.stdin.pipe(writeStream)
-        console.info('logging')
+        process.stdin.pipe(process.stdout)
       } catch (error) {
         console.log(error.message)
       }


### PR DESCRIPTION
The goal is to be able to pipe more than one pino transport:
```
node index.js | pino-datadog | pino-papertrail | pino-pretty
```