### PR TITLE
add support for specifying ddtags for all logs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -49,6 +49,12 @@ Type: `String` *(optional)*
 
 Set a default source to all the logs sent to datadog
 
+#### ddtags
+
+Type: `String` *(optional)*
+
+Set a default list of tags for all the logs sent to datadog
+
 #### service 
 
 Type: `String` *(optional)*

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -19,10 +19,11 @@ $ node foo | pino-datadog --key blablabla
 You can pass the following options via cli arguments or use the environment variable associated:
 
 | Short command | Full command | Environment variable | Description |
-| ------------- | ------------ |-------------|
+| --- | --- | --- | --- |
 | -V | --version | | Output the version number |
 | -k | --key &lt;apikey&gt; | DD_API_KEY | The API key that can be found in your DataDog account |
 | -d | --ddsource &lt;source&gt; | DD_SOURCE | Default source for the logs |
+| -t | --ddtags &lt;tags&gt; | DD_TAGS | Default list of tags for the logs |
 | -s, --service &lt;service&gt; | DD_SERVICE | Default service for the logs |
 | | --hostname &lt;hostname&gt; | DD_HOSTNAME | Default hostname for the logs |
 | -e | --eu | DD_EU | Use Datadog EU site |

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,7 @@ function main () {
     .version(pkg.version)
     .option('-k, --key <key>', 'DataDog API Key')
     .option('-d, --ddsource <source>', 'Default source for the logs')
+    .option('-t, --ddtags <tags>', 'Default tags for the logs')
     .option('-s, --service <service>', 'Default service for the logs')
     .option('--hostname <hostname>', 'Default hostname for the logs')
     .option('-e, --eu', 'Use Datadog EU site')
@@ -19,6 +20,7 @@ function main () {
         const config = {
           apiKey: options.key || process.env.DD_API_KEY,
           ddsource: options.ddsource || process.env.DD_SOURCE,
+          ddtags: options.ddtags || process.env.DD_TAGS,
           service: options.service || process.env.DD_SERVICE,
           hostname: options.hostname || process.env.DD_HOSTNAME,
           eu: options.eu || !!process.env.DD_EU

--- a/src/datadog.js
+++ b/src/datadog.js
@@ -21,6 +21,9 @@ class Client {
       if (this._options.ddsource) {
         params.ddsource = this._options.ddsource
       }
+      if (this._options.ddtags) {
+        params.ddtags = this._options.ddtags
+      }
       if (this._options.service) {
         params.service = this._options.service
       }

--- a/test/datadog.test.js
+++ b/test/datadog.test.js
@@ -107,6 +107,7 @@ test('inserts sends extra parameters ', async t => {
   const client = new tested.Client({
     apiKey: '1234567890',
     ddsource: 'source',
+    ddtags: 'tag-1,tag-2,tag-3',
     service: 'service',
     hostname: 'foobar.com'
   })
@@ -122,6 +123,7 @@ test('inserts sends extra parameters ', async t => {
       {
         params: {
           ddsource: 'source',
+          ddtags: 'tag-1,tag-2,tag-3',
           service: 'service',
           hostname: 'foobar.com'
         }


### PR DESCRIPTION
I'd like to propose adding support for specifying the `ddtags` parameter once for all logs. In our use case of Datadog we only use tags at an application level.

By adding the ability to specify the tags once, we simplify all subsequent calls to the logger.