### PR TITLE
Return undefined instead of null on invalid JSON

### DIFF
--- a/src/streams.js
+++ b/src/streams.js
@@ -12,7 +12,7 @@ function batchStream (size) {
 function parseJsonStream () {
   return split2(function (str) {
     const result = fastJsonParse(str)
-    if (result.err) return null
+    if (result.err) return
     return result.value
   })
 }


### PR DESCRIPTION
Ran into an issue with this log transport when using [ts-node-dev](https://github.com/whitecolor/ts-node-dev):

```
events.js:187
      throw er; // Unhandled 'error' event
      ^

NodeError: stream.push() after EOF
    at readableAddChunk (/Users/john/Projects/Personal/plexbuddy/node_modules/readable-stream/lib/_stream_readable.js:269:30)
    at Transform.Readable.push (/Users/john/Projects/Personal/plexbuddy/node_modules/readable-stream/lib/_stream_readable.js:240:10)
    at Transform.push (/Users/john/Projects/Personal/plexbuddy/node_modules/readable-stream/lib/_stream_transform.js:139:32)
    at push (/Users/john/Projects/Personal/plexbuddy/node_modules/split2/index.js:65:10)
    at Transform.transform [as _transform] (/Users/john/Projects/Personal/plexbuddy/node_modules/split2/index.js:43:5)
    at Transform._read (/Users/john/Projects/Personal/plexbuddy/node_modules/readable-stream/lib/_stream_transform.js:177:10)
    at Transform._write (/Users/john/Projects/Personal/plexbuddy/node_modules/readable-stream/lib/_stream_transform.js:164:83)
    at doWrite (/Users/john/Projects/Personal/plexbuddy/node_modules/readable-stream/lib/_stream_writable.js:405:139)
    at writeOrBuffer (/Users/john/Projects/Personal/plexbuddy/node_modules/readable-stream/lib/_stream_writable.js:394:5)
    at Transform.Writable.write (/Users/john/Projects/Personal/plexbuddy/node_modules/readable-stream/lib/_stream_writable.js:303:11)
Emitted 'error' event on Pumpify instance at:
    at errorOrDestroy (internal/streams/destroy.js:108:12)
    at Pumpify.onerror (_stream_readable.js:758:7)
    at Pumpify.emit (events.js:210:5)
    at Pumpify.Duplexify._destroy (/Users/john/Projects/Personal/plexbuddy/node_modules/duplexify/index.js:195:15)
    at /Users/john/Projects/Personal/plexbuddy/node_modules/duplexify/index.js:185:10
    at processTicksAndRejections (internal/process/task_queues.js:75:11)
```

It worked fine with straight node. Turns out the issue was the non-JSON lines that `tsnd` sends to stdout in addition to your app's logs. `null` is a special case for object streams, and the next stream in the pump is just that. By returning `undefined` on invalid JSON instead of `null` this prevents the error.