### PR TITLE
Optionally disable output to _stdout_

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -29,5 +29,6 @@ You can pass the following options via cli arguments or use the environment vari
 | -e | --eu | DD_EU | Use Datadog EU site |
 | -b | --batch &lt;size&gt; | | The number of log messages to send as a single batch (defaults to 1) |
 | -h | --help | | Output usage information |
+| | --no-stdout | | Disable output to stdout |
 
 See the [API](./API.md) documentation for details.

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,6 +15,7 @@ function main () {
     .option('-s, --service <service>', 'Default service for the logs')
     .option('--hostname <hostname>', 'Default hostname for the logs')
     .option('-e, --eu', 'Use Datadog EU site')
+    .option('--no-stdout', 'Disable output to stdout')
     .action(async options => {
       try {
         const config = {
@@ -27,7 +28,10 @@ function main () {
         }
         const writeStream = await pinoDataDog.createWriteStream(config)
         process.stdin.pipe(writeStream)
-        process.stdin.pipe(process.stdout)
+
+        if (!options.noStdout) {
+          process.stdin.pipe(process.stdout)
+        }
       } catch (error) {
         console.log(error.message)
       }


### PR DESCRIPTION
In cases where you have the datadog agent installed and log collection enabled, adding this package sends two copies of every log to datadog.

Addresses #37 