### PR TITLE
Implement keepMsg option, to optionally not delete msg parameter

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -77,3 +77,9 @@ Set a default service to all the logs sent to datadog
 Type: `String` *(optional)*
 
 Set a default hostname to all the logs sent to datadog
+
+#### keepMsg
+
+Type: `Boolean` *(optional)*
+
+Keep the `msg` attribute in the log record. Used to allow a Datadog facet on the message.

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ function createWriteStreamSync (options = {}) {
   const { size = 1 } = options
 
   const parseJsonStream = streams.parseJsonStream()
-  const toLogEntryStream = streams.toLogEntryStream()
+  const toLogEntryStream = streams.toLogEntryStream(options)
   const batchStream = streams.batchStream(size)
 
   const client = new datadog.Client(options)

--- a/src/streams.js
+++ b/src/streams.js
@@ -36,7 +36,7 @@ function toLogEntry (item) {
   const ddtags = Object.keys(objTags).map(k => { return `${k}:${objTags[k]}` }).join(',')
 
   const entry = Object.assign({}, item, { timestamp, status, message, host, service, ddsource, ddtags })
-  delete entry.time; delete entry.level; delete entry.msg; delete entry.hostname; delete entry.source; delete entry.labels; delete entry.tags
+  delete entry.time; delete entry.level; delete entry.hostname; delete entry.source; delete entry.labels; delete entry.tags
   if (!service) { delete entry.service }
   if (!ddsource) { delete entry.ddsource }
   if (!ddtags) { delete entry.ddtags }
@@ -46,6 +46,9 @@ function toLogEntry (item) {
 function toLogEntryStream (options = {}) {
   return through2.obj(function transport (chunk, enc, cb) {
     const entry = toLogEntry(chunk)
+    if (!options.keepMsg) {
+      delete entry.msg
+    }
     cb(null, entry)
   })
 }

--- a/test/streams.test.js
+++ b/test/streams.test.js
@@ -65,3 +65,20 @@ test('transforms pino log messages', t => {
   logs.forEach(log => writeStream.write(log))
   writeStream.end()
 })
+
+test('transforms pino log stream, leaves msg alone', t => {
+  const writeStream = tested.toLogEntryStream({ keepMsg: true })
+  const output = []
+  const logs = [
+    { level: 10, time: 1532081790710, msg: 'trace message' }
+  ]
+  writeStream.on('data', chunk => {
+    output.push(chunk)
+  }).on('end', () => {
+    t.equal(output[0].message, 'trace message')
+    t.equal(output[0].msg, 'trace message')
+    t.end()
+  })
+  logs.forEach(log => writeStream.write(log))
+  writeStream.end()
+})


### PR DESCRIPTION
Adds the keepMsg option which allows the original 'msg' parameter to be passed through to Datadog.

It's sometimes useful to have the Datadog facet capability on log messages, particularly when the text of
the messages is short and does not contain variables, which is possible with JSON logging since the payload
contains the variable data.

However, Datadog does not permit a facet to be made on the 'message' attribute, but if
the attribute had a different name, it works fine. Datadog does not allow the 'message' attribute to be 
remapped either.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
