### PR TITLE
No wait

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -83,3 +83,12 @@ Set a default hostname to all the logs sent to datadog
 Type: `Boolean` *(optional)*
 
 Keep the `msg` attribute in the log record. Used to allow a Datadog facet on the message.
+
+#### noWait
+
+Type: `Boolean` *(optional)*
+
+Only available in a node environment, this provides a substantial performance improvement (circa <10ms vs 300-500ms)
+when sending the log messages to DataDog because it does not wait for the HTTP POST response. This is particularly
+useful for AWS Lambda functions where the logging stream must be closed before the function returns in order
+to avoid losing data.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,9 @@ Changes are grouped by:
 
 ## [Unreleased](https://github.com/ovhemert/pino-datadog/compare/v2.0.1...HEAD)
 
-- ...
+### Added
+
+- Add noWait parameter for better perfornace in node environments by [@francisu](https://github.com/francisu)
 
 ## [2.0.1](https://github.com/ovhemert/pino-datadog/compare/v2.0.0...v2.0.1) - 2020-09-09
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped by:
 
 ### Added
 
-- Add noWait parameter for better perfornace in node environments by [@francisu](https://github.com/francisu)
+- Add noWait parameter for better performance in node environments by [@francisu](https://github.com/francisu)
 
 ## [2.0.1](https://github.com/ovhemert/pino-datadog/compare/v2.0.0...v2.0.1) - 2020-09-09
 

--- a/src/datadog.js
+++ b/src/datadog.js
@@ -14,9 +14,9 @@ class Client {
       return
     }
     try {
-      const domain = this._options.eu
-        ? 'https://http-intake.logs.datadoghq.eu'
-        : 'https://http-intake.logs.datadoghq.com'
+      const hostname = this._options.eu
+        ? 'http-intake.logs.datadoghq.eu'
+        : 'http-intake.logs.datadoghq.com'
       const params = {}
       if (this._options.ddsource) {
         params.ddsource = this._options.ddsource

--- a/src/datadog.js
+++ b/src/datadog.js
@@ -31,9 +31,32 @@ class Client {
         params.hostname = this._options.hostname
       }
 
-      const url = `${domain}/v1/input/${this._options.apiKey}`
-      const result = await axios.post(url, data, { params })
-      return result
+      const basePath = `/v1/input/${this._options.apiKey}`
+      if (this._options.noWait) {
+        const http = require('https')
+        const dataString = JSON.stringify(data)
+        let paramString = ''
+        Object.keys(params).forEach(k => { paramString += `&${k}=${params[k]}` })
+        if (paramString.length > 0) {
+          paramString = '?' + paramString.substring(1)
+        }
+        const options = {
+          hostname,
+          path: `${basePath}${paramString}`,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json;charset=utf-8',
+            'Content-Length': dataString.length
+          }
+        }
+        const req = http.request(options)
+        req.write(dataString)
+        req.end()
+        return {}
+      } else {
+        const url = `${hostname}${basePath}`
+        return await axios.post(`https://${url}`, data, { params })
+      }
     } catch (err) {
       console.error('The previous log have not been saved')
       console.error(`${err.message}\n${err.stack}`)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

This adds a 'noWait' option which is (very) useful in the node/AWS Lambda case for logging. The current implementation
does an HTTP POST and waits for the reply, taking anywhere from 200-500ms, which delays the response of the Lambda
function for that period, greatly slowing down the application. Furthermore, if the PORT is somehow rejected, it just
does a console.log indicating an error has happened, which is not very meaningful (it does not retry for example).

WIth the noWait option, the HTTP POST is issued (using a lower-level nodejs API) but the reply is not waited for, which reduces the time for logging to < 10ms. 

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
