### PR TITLE
Add client tokens support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -46,7 +46,13 @@ const writeStream = datadog.createWriteStreamSync({ apiKey: 'blablabla', size: 1
 
 Type: `String` *(required)*
 
-The API key that can be found in your DataDog account (Integration > APIs).
+The API key that can be found in your DataDog account (Integration > APIs). Mutually excluse with `clientToken`.
+
+#### clientToken
+
+Type: `String` *(required)*
+
+The client token that can be found in your DataDog account (Integration > APIs). Mutually excluse with `apiKey`.
 
 #### size
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,9 @@ Changes are grouped by:
 
 ## [Unreleased](https://github.com/ovhemert/pino-datadog/compare/v2.0.2...HEAD)
 
-- ...
+### Added
+
+- Add client tokens support by [ngryman](https://github.com/ngryman)
 
 ## [2.0.2](https://github.com/ovhemert/pino-datadog/compare/v2.0.1...v2.0.2) - 2021-02-25
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -22,6 +22,7 @@ You can pass the following options via cli arguments or use the environment vari
 | --- | --- | --- | --- |
 | -V | --version | | Output the version number |
 | -k | --key &lt;apikey&gt; | DD_API_KEY | The API key that can be found in your DataDog account |
+| -c | --token &lt;clientToken&gt; | DD_CLIENT_TOKEN | The client token that can be found in your DataDog account |
 | -d | --ddsource &lt;source&gt; | DD_SOURCE | Default source for the logs |
 | -t | --ddtags &lt;tags&gt; | DD_TAGS | Default list of tags for the logs |
 | -s, --service &lt;service&gt; | DD_SERVICE | Default service for the logs |

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,6 +10,7 @@ function main () {
   program
     .version(pkg.version)
     .option('-k, --key <key>', 'DataDog API Key')
+    .option('-c, --token <token>', 'DataDog client token')
     .option('-d, --ddsource <source>', 'Default source for the logs')
     .option('-t, --ddtags <tags>', 'Default tags for the logs')
     .option('-s, --service <service>', 'Default service for the logs')
@@ -21,6 +22,7 @@ function main () {
       try {
         const config = {
           apiKey: options.key || process.env.DD_API_KEY,
+          clientToken: options.token || process.env.DD_CLIENT_TOKEN,
           ddsource: options.ddsource || process.env.DD_SOURCE,
           ddtags: options.ddtags || process.env.DD_TAGS,
           service: options.service || process.env.DD_SERVICE,

--- a/src/datadog.js
+++ b/src/datadog.js
@@ -14,9 +14,10 @@ class Client {
       return
     }
     try {
+      const endpoint = this._options.clientToken ? 'browser' : 'logs'
       const domain = this._options.eu
-        ? 'https://http-intake.logs.datadoghq.eu'
-        : 'https://http-intake.logs.datadoghq.com'
+        ? `https://${endpoint}-http-intake.logs.datadoghq.eu`
+        : `https://${endpoint}-http-intake.logs.datadoghq.com`
       const params = {}
       if (this._options.ddsource) {
         params.ddsource = this._options.ddsource
@@ -31,7 +32,8 @@ class Client {
         params.hostname = this._options.hostname
       }
 
-      const url = `${domain}/v1/input/${this._options.apiKey}`
+      const token = this._options.clientToken || this._options.apiKey
+      const url = `${domain}/v1/input/${token}`
       const result = await axios.post(url, data, { params })
       return result
     } catch (err) {

--- a/test/datadog.test.js
+++ b/test/datadog.test.js
@@ -76,7 +76,25 @@ test('inserts sends com url and api key', async t => {
   t.ok(stubPost.called)
   t.ok(
     stubPost.calledWithMatch(
-      'https://http-intake.logs.datadoghq.com/v1/input/1234567890',
+      'https://logs-http-intake.logs.datadoghq.com/v1/input/1234567890',
+      items,
+      { params: {} }
+    )
+  )
+  stubPost.restore()
+  t.end()
+})
+
+test('inserts sends client token', async t => {
+  const client = new tested.Client({ clientToken: '1234567890' })
+  const stubPost = sinon.stub(axios, 'post')
+  const items = [{ message: 'hello world !' }]
+
+  await client.insert(items)
+  t.ok(stubPost.called)
+  t.ok(
+    stubPost.calledWithMatch(
+      'https://browser-http-intake.logs.datadoghq.com/v1/input/1234567890',
       items,
       { params: {} }
     )
@@ -94,7 +112,7 @@ test('inserts sends eu url and api key', async t => {
   t.ok(stubPost.called)
   t.ok(
     stubPost.calledWithMatch(
-      'https://http-intake.logs.datadoghq.eu/v1/input/1234567890',
+      'https://logs-http-intake.logs.datadoghq.eu/v1/input/1234567890',
       items,
       { params: {} }
     )
@@ -118,7 +136,7 @@ test('inserts sends extra parameters ', async t => {
   t.ok(stubPost.called)
   t.ok(
     stubPost.calledWithMatch(
-      'https://http-intake.logs.datadoghq.com/v1/input/1234567890',
+      'https://logs-http-intake.logs.datadoghq.com/v1/input/1234567890',
       items,
       {
         params: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

## Description

Hi, first thanks for this Pino transport!

We want to use it to track the usage of one of our CLI. It will be deployed in untrusted environments. As a consequence, using the API key is a no-go for us.

Datadog provides another way to authenticate from untrusted environments: client tokens. These tokens are initially made to be used in a browser environment. But it would perfectly the needs of a public CLI tool as well.

## Feature

This PR adds a new `clientToken` option that is mutually exclusive with `apiKey`:

```js
const writeStream = await datadog.createWriteStream({
    clientToken: 'pub1234567890'
})
```

If both are specified, `clientToken` will take precedence. We can change that with an explicit error if you prefer.

The CLI exposes the corresponding `-c, --token` flag. I'm not exactly sure how to name it. Let me know!

## Implementation

Datadog uses 2 different endpoints depending on the authentication scheme:

* API key: `https://logs-http-intake.logs.datadoghq.com`
* Client token: `https://browser-http-intake.logs.datadoghq.com`

You can find these endpoints in their SDK [implementation](https://github.com/DataDog/browser-sdk/blob/f92eeb6ef27002257f491a57cb6dac2027857eb0/packages/core/src/domain/transportConfiguration.ts#L5-L19).

To choose the appropriate endpoint, I preferred to be explicit and introduce a new `clientToken` option instead of reusing the `apiKey` one.

However, we could also keep only on the `apiKey` option if you prefer. Client tokens always start with `pub`, so we can leverage that to choose the appropriate endpoint. Note that we would depend on the way tokens are implemented, which could be a bit risky. If Datadog decides to change the format of the token, the code will break.

Let me know what you prefer.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
