### PR TITLE
Allow both global and log-level tags

### DIFF
--- a/src/datadog.js
+++ b/src/datadog.js
@@ -21,15 +21,26 @@ class Client {
       if (this._options.ddsource) {
         params.ddsource = this._options.ddsource
       }
-      if (this._options.ddtags) {
-        params.ddtags = this._options.ddtags
-      }
       if (this._options.service) {
         params.service = this._options.service
       }
       if (this._options.hostname) {
         params.hostname = this._options.hostname
       }
+
+      items.forEach((item) => {
+        // per-log tags override global / config-level tags
+        const tags = Object.assign({}, this._options.ddtags, item.ddtags)
+        const tagEntries = Object.entries(tags)
+
+        if (tagEntries.length > 0) {
+          item.ddtags = tagEntries
+            .map(([k, v]) => (v === true ? k : `${k}:${v}`))
+            .join(",")
+        } else {
+          delete item.ddtags
+        }
+      });
 
       const url = `${domain}/v1/input/${this._options.apiKey}`
       const result = await axios.post(url, data, { params })

--- a/src/streams.js
+++ b/src/streams.js
@@ -32,14 +32,12 @@ function toLogEntry (item) {
   const host = item.hostname || ''
   const service = item.service || ''
   const ddsource = item.ddsource || item.source || ''
-  const objTags = (item.labels || item.tags || {})
-  const ddtags = Object.keys(objTags).map(k => { return `${k}:${objTags[k]}` }).join(',')
+  const ddtags = Object.assign({}, item.labels, item.tags, item.ddtags)
 
   const entry = Object.assign({}, item, { timestamp, status, message, host, service, ddsource, ddtags })
   delete entry.time; delete entry.level; delete entry.hostname; delete entry.source; delete entry.labels; delete entry.tags
   if (!service) { delete entry.service }
   if (!ddsource) { delete entry.ddsource }
-  if (!ddtags) { delete entry.ddtags }
   return entry
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

We have the need for global / configuration-level tags _and_ log-level tags. In the current implementation that is not possible, because the per-log `ddtags` are ignored if `ddtags` is also sent as a property of `params` on the http request to the datadog API. That appears to be an issue with the API that we need to work around here.

I have tested this manually but will add unit tests if possible before submitting for review (hence the draft status). I will also look at updating the documentation when I do that.

#### Checklist

- [ ] run `npm run test`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows *Code Of Conduct*
