### PR TITLE
Add `eu` parameter to the API docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -83,3 +83,9 @@ Set a default hostname to all the logs sent to datadog
 Type: `Boolean` *(optional)*
 
 Keep the `msg` attribute in the log record. Used to allow a Datadog facet on the message.
+
+#### eu
+
+Type: `Boolean` *(optional)*
+
+Sends logs to Datadog's EU intake endpoint instead of US (which is default).


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

This is a simple documentation fix that adds the `eu` parameter to `API.md` as it was missing.

#### Checklist

- [ ] run `npm run test`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
