### PR TITLE
Pass host to DD, not hostname

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -72,11 +72,11 @@ Type: `String` *(optional)*
 
 Set a default service to all the logs sent to datadog
 
-#### hostname
+#### host (hostname is also allowed)
 
 Type: `String` *(optional)*
 
-Set a default hostname to all the logs sent to datadog
+Set a default host to all the logs sent to datadog
 
 #### keepMsg
 

--- a/src/datadog.js
+++ b/src/datadog.js
@@ -27,8 +27,8 @@ class Client {
       if (this._options.service) {
         params.service = this._options.service
       }
-      if (this._options.hostname) {
-        params.hostname = this._options.hostname
+      if (this._options.hostname || this._options.host) {
+        params.host = this._options.hostname || this._options.host
       }
 
       const url = `${domain}/v1/input/${this._options.apiKey}`

--- a/test/datadog.test.js
+++ b/test/datadog.test.js
@@ -125,7 +125,38 @@ test('inserts sends extra parameters ', async t => {
           ddsource: 'source',
           ddtags: 'tag-1,tag-2,tag-3',
           service: 'service',
-          hostname: 'foobar.com'
+          host: 'foobar.com'
+        }
+      }
+    )
+  )
+  stubPost.restore()
+  t.end()
+})
+
+test('inserts sends extra parameters also for host', async t => {
+  const client = new tested.Client({
+    apiKey: '1234567890',
+    ddsource: 'source',
+    ddtags: 'tag-1,tag-2,tag-3',
+    service: 'service',
+    host: 'foobar.com'
+  })
+  const stubPost = sinon.stub(axios, 'post')
+  const items = [{ message: 'hello world !' }]
+
+  await client.insert(items)
+  t.ok(stubPost.called)
+  t.ok(
+    stubPost.calledWithMatch(
+      'https://http-intake.logs.datadoghq.com/v1/input/1234567890',
+      items,
+      {
+        params: {
+          ddsource: 'source',
+          ddtags: 'tag-1,tag-2,tag-3',
+          service: 'service',
+          host: 'foobar.com'
         }
       }
     )


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

Hi!

It seems that passing `hostname` to Datadog doesn't get translated into `host` on their end.

See this screenshot where `hostname` is passed in the data object of the log, but not shown in the log entry - it says `simons-mbp-2.lan`.

<img width="2134" alt="image" src="https://user-images.githubusercontent.com/1343979/186133503-8996d5f1-4832-4904-8802-9822b30be640.png">

For the other log I have applied my change in this PR, and we can see that `host` in the log entry corresponds to what I sent as `host` in the data object:

<img width="2134" alt="image" src="https://user-images.githubusercontent.com/1343979/186133662-dc2de18c-d9da-46e4-9843-c0249741dece.png">

In order to not break the API, we can still have `hostname` parameter untouched, but also allow it to be `host` to align with Datadog's naming.

This is the test output. Please advise if you want it in any other format.

```console
# simonauner at simons-mbp-2.lan in ~/code/pino-datadog on git:rename-hostname-to-host ✖︎ [12:21:35]
→ npm test

> pino-datadog@2.0.2 test /Users/simonauner/code/pino-datadog
> standard && tap test/*.test.js --coverage --100

 PASS  test/streams.test.js 15 OK 36.545ms
 PASS  test/index.test.js 2 OK 20.579ms
test/datadog.test.js 2> The previous log have not been saved
test/datadog.test.js 2> Error
test/datadog.test.js 2> Error: Error
test/datadog.test.js 2>     at Object.rejects (/Users/simonauner/code/pino-datadog/node_modules/sinon/lib/sinon/default-behaviors.js:193:22)
test/datadog.test.js 2>     at Object.proto.<computed> [as rejects] (/Users/simonauner/code/pino-datadog/node_modules/sinon/lib/sinon/behavior.js:238:12)
test/datadog.test.js 2>     at Function.<anonymous> (/Users/simonauner/code/pino-datadog/node_modules/sinon/lib/sinon/behavior.js:231:46)
test/datadog.test.js 2>     at Test.<anonymous> (/Users/simonauner/code/pino-datadog/test/datadog.test.js:19:46)
test/datadog.test.js 2>     at TapWrap.runInAsyncScope (async_hooks.js:197:9)
test/datadog.test.js 2>     at Test.cb (/Users/simonauner/code/pino-datadog/node_modules/tap/lib/test.js:147:40)
test/datadog.test.js 2>     at /Users/simonauner/code/pino-datadog/node_modules/tap/lib/test.js:385:21
test/datadog.test.js 2>     at Test.main (/Users/simonauner/code/pino-datadog/node_modules/tap/lib/test.js:392:7)
test/datadog.test.js 2>     at TapWrap.runInAsyncScope (async_hooks.js:197:9)
test/datadog.test.js 2>     at Test.runMain (/Users/simonauner/code/pino-datadog/node_modules/tap/lib/base.js:193:15)
 PASS  test/datadog.test.js 17 OK 56.717ms

                         
  🌈 SUMMARY RESULTS 🌈  
                         

Suites:   3 passed, 3 of 3 completed
Asserts:  34 passed, of 34
Time:     1s
------------|----------|----------|----------|----------|-------------------|
File        |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------|----------|----------|----------|----------|-------------------|
All files   |      100 |      100 |      100 |      100 |                   |
 datadog.js |      100 |      100 |      100 |      100 |                   |
 index.js   |      100 |      100 |      100 |      100 |                   |
 streams.js |      100 |      100 |      100 |      100 |                   |
------------|----------|----------|----------|----------|-------------------|

> pino-datadog@2.0.2 posttest /Users/simonauner/code/pino-datadog
> tap --coverage --coverage-report=lcovonly
```

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
