### PR TITLE
Add site option to API and CLI

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -83,3 +83,9 @@ Set a default hostname to all the logs sent to datadog
 Type: `Boolean` *(optional)*
 
 Keep the `msg` attribute in the log record. Used to allow a Datadog facet on the message.
+
+#### site
+
+Type: `String` *(optional)*
+
+Specify a datadog site (i.e. US, US3, US5, etc.). Defaults to US. If using EU, use the `eu` option instead. Fedramp not supported.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -29,6 +29,7 @@ You can pass the following options via cli arguments or use the environment vari
 | -e | --eu | DD_EU | Use Datadog EU site |
 | -b | --batch &lt;size&gt; | | The number of log messages to send as a single batch (defaults to 1) |
 | -h | --help | | Output usage information |
+| | --site &lt;site&gt; | | Specify a datadog site (i.e. US, US3, US5, etc.). Defaults to US. If using EU, use the `eu` option instead.  |
 | | --no-stdout | | Disable output to stdout |
 
 See the [API](./API.md) documentation for details.

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,6 +16,7 @@ function main () {
     .option('--hostname <hostname>', 'Default hostname for the logs')
     .option('-e, --eu', 'Use Datadog EU site')
     .option('-b, --batch <size>', 'The number of log messages to send as a single batch (defaults to 1)')
+    .option('--site <site>', 'Specify a datadog site (i.e. US, US3, US5, etc.). Defaults to US. If using EU, use the `eu` option instead.')
     .option('--no-stdout', 'Disable output to stdout')
     .action(async options => {
       try {
@@ -26,7 +27,8 @@ function main () {
           service: options.service || process.env.DD_SERVICE,
           hostname: options.hostname || process.env.DD_HOSTNAME,
           eu: options.eu || !!process.env.DD_EU,
-          size: options.batch || 1
+          size: options.batch || 1,
+          site: options.site
         }
         const writeStream = await pinoDataDog.createWriteStream(config)
         process.stdin.pipe(writeStream)

--- a/src/datadog.js
+++ b/src/datadog.js
@@ -14,9 +14,17 @@ class Client {
       return
     }
     try {
+      let site = ''
+      if (this._options.site) {
+        const siteLower = this._options.site.toLowerCase()
+        if (siteLower !== 'us' && siteLower !== 'eu') {
+          site = `${siteLower}.`
+        }
+      }
+
       const domain = this._options.eu
         ? 'https://http-intake.logs.datadoghq.eu'
-        : 'https://http-intake.logs.datadoghq.com'
+        : `https://http-intake.logs.${site}datadoghq.com`
       const params = {}
       if (this._options.ddsource) {
         params.ddsource = this._options.ddsource

--- a/test/datadog.test.js
+++ b/test/datadog.test.js
@@ -103,6 +103,60 @@ test('inserts sends eu url and api key', async t => {
   t.end()
 })
 
+test('insert sends to specified site', async t => {
+  const client = new tested.Client({ apiKey: '1234567890', site: 'us3' })
+  const stubPost = sinon.stub(axios, 'post')
+  const items = [{ message: 'hello world !' }]
+
+  await client.insert(items)
+  t.ok(stubPost.called)
+  t.ok(
+    stubPost.calledWithMatch(
+      'https://http-intake.logs.us3.datadoghq.com/v1/input/1234567890',
+      items,
+      { params: {} }
+    )
+  )
+  stubPost.restore()
+  t.end()
+})
+
+test('insert uses lowercase for site', async t => {
+  const client = new tested.Client({ apiKey: '1234567890', site: 'US5' })
+  const stubPost = sinon.stub(axios, 'post')
+  const items = [{ message: 'hello world !' }]
+
+  await client.insert(items)
+  t.ok(stubPost.called)
+  t.ok(
+    stubPost.calledWithMatch(
+      'https://http-intake.logs.us5.datadoghq.com/v1/input/1234567890',
+      items,
+      { params: {} }
+    )
+  )
+  stubPost.restore()
+  t.end()
+})
+
+test('insert does not specify site if default US is provided', async t => {
+  const client = new tested.Client({ apiKey: '1234567890', site: 'US' })
+  const stubPost = sinon.stub(axios, 'post')
+  const items = [{ message: 'hello world !' }]
+
+  await client.insert(items)
+  t.ok(stubPost.called)
+  t.ok(
+    stubPost.calledWithMatch(
+      'https://http-intake.logs.datadoghq.com/v1/input/1234567890',
+      items,
+      { params: {} }
+    )
+  )
+  stubPost.restore()
+  t.end()
+})
+
 test('inserts sends extra parameters ', async t => {
   const client = new tested.Client({
     apiKey: '1234567890',


### PR DESCRIPTION
## Description
Datadog now offers different sites in addition to EU (I imagine to load balance a bit). Here is the [link to site docs](https://docs.datadoghq.com/getting_started/site/). When your account uses a different site, the URL for ingesting logs is different. [Here is a link to the API docs](https://docs.datadoghq.com/api/latest/logs/). On the API docs page if you select V1 and a different site, you'll see that the URL is different for ingesting logs.

![Screen Shot 2022-12-09 at 8 22 34 AM](https://user-images.githubusercontent.com/8452261/206735339-a31866c2-54e1-4b95-9884-e5284c002ea4.png)


This PR
- Adds a `site` option to allow you to change the datadog site (along with `--site` for cli). This option updates the url.
- Updates documentation
- Adds tests for new code

#### Checklist

- [x] run `npm run test`
![Screen Shot 2022-12-09 at 8 38 03 AM](https://user-images.githubusercontent.com/8452261/206738171-81f41af8-f51e-4764-a3d1-b2cd34a381d8.png)

- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
