### PR TITLE
Add test reporter to test package.json script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev:cli": "node ./test/debug.js | node ./src/cli.js",
     "lint": "standard",
-    "test": "standard && tap test/*.test.js --coverage --100",
+    "test": "standard && tap test/*.test.js --coverage --100 --reporter classic",
     "test:report": "standard && tap test/*.test.js --coverage  --coverage-report=html --100",
     "posttest": "tap --coverage --coverage-report=lcovonly"
   },


### PR DESCRIPTION
## Description
Currently on master when I run `npm run test`, it fails with the following error
![Screen Shot 2022-12-09 at 8 41 10 AM](https://user-images.githubusercontent.com/8452261/206739123-dcbaaf94-ae7f-4252-98da-c9d9c91f7138.png)

I found [this related issue](https://github.com/tapjs/node-tap/issues/624) which links to [this suggested fix](https://github.com/nodejs/citgm/issues/852#issuecomment-816317278) of adding a reporter.

After the package.json change:

![Screen Shot 2022-12-09 at 8 41 50 AM](https://user-images.githubusercontent.com/8452261/206739429-007199e4-149b-400a-9848-1503e9c52df1.png)



#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
